### PR TITLE
Fixes to compile on OS X

### DIFF
--- a/main.c
+++ b/main.c
@@ -7,6 +7,11 @@
 // Define _POSIX_SOURCE to enable sigaction(). See `man 2 sigaction'
 #define _POSIX_SOURCE
 
+// Needed for Apple clang to recognize SIGWINCH
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE
+#endif
+
 #include "editor.h"
 #include "util.h"
 #include "undo.h"


### PR DESCRIPTION
Apple's clang doesn't recognize the SIGWINCH macro unless certain
flags are defined.