### PR TITLE
Adding Ctrl+U and Ctrl+D to be used for Page Up and Page Down respectively.

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -872,7 +872,9 @@ void editor_process_keypress(struct editor* e) {
 		// TODO: when END on the last line and octets are less than max per line,
 		// the offset is a bit fux0red.
 		case KEY_END:      e->cursor_x = e->octets_per_line; return;
+		case KEY_CTRL_U:
 		case KEY_PAGEUP:   editor_scroll(e, -(e->screen_rows) + 2); return;
+		case KEY_CTRL_D:
 		case KEY_PAGEDOWN: editor_scroll(e, e->screen_rows - 2); return;
 		}
 	}

--- a/util.h
+++ b/util.h
@@ -13,8 +13,10 @@
 // Key enumeration, returned by read_key().
 enum key_codes {
 	KEY_NULL      = 0,
+	KEY_CTRL_D    = 0x04,
 	KEY_CTRL_Q    = 0x11, // DC1, to exit the program.
 	KEY_CTRL_S    = 0x13, // DC2, to save the current buffer.
+	KEY_CTRL_U    = 0x15,
 	KEY_ESC       = 0x1b, // ESC, for things like keys up, down, left, right, delete, ...
 	KEY_ENTER     = 0x0d,
 	KEY_BACKSPACE = 0x7f,


### PR DESCRIPTION
Very simple change to allow for Page-Up and Page-Down on keyboards that don't have the actual keys or are a pain to get to. Key bindings match those of VIM.