### PR TITLE
Append and insert are the same on an empty buffer

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -565,7 +565,7 @@ void editor_insert_byte_at_offset(struct editor* e, unsigned int offset, char x,
 	// this extra byte.
 	e->contents = realloc(e->contents, e->content_length + 1);
 
-	if (after) {
+	if (after && e->content_length) { // append is the same as insert when buffer is empty
 		offset++;
 	}
 	//          v


### PR DESCRIPTION
Append and insert both insert a new character at index 0 on an empty buffer. 
Add check for the empty buffer before incrementing offset and Fixes #4.
The bug causes an append on the empty buffer to increment the offset 
to 1 instead of 0 and set the character at index 1, which is out of bounds
and segfaults.