### PR TITLE
Implement redo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Keys which can be used:
 	n       : Search for next occurrence.
 	N       : Search for previous occurrence.
 	u       : Undo the last action.
-	R       : Redo the last undone action.
+	CTRL+R  : Redo the last undone action.
 
 	a       : Append mode. Appends a byte after the current cursor position.
 	A       : Append mode. Appends the literal typed keys (except ESC).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Keys which can be used:
 	n       : Search for next occurrence.
 	N       : Search for previous occurrence.
 	u       : Undo the last action.
+	R       : Redo the last undone action.
 
 	a       : Append mode. Appends a byte after the current cursor position.
 	A       : Append mode. Appends the literal typed keys (except ESC).
@@ -84,4 +85,3 @@ details, Use The Source Luke.
 
 1. Perhaps a configuration file to control the colors or some default settings.
 1. Searching a byte sequence (not by ASCII) would be handy.
-1. Undo works, but redo is not yet implemented.

--- a/editor.c
+++ b/editor.c
@@ -1074,8 +1074,15 @@ void editor_process_keypress(struct editor* e) {
 }
 
 void editor_undo(struct editor* e) {
-	struct action* last_action = e->undo_list->tail;
-	if (last_action == NULL) {
+	struct action* last_action = e->undo_list->curr;
+
+	if (e->undo_list->curr_status == AFTER_TAIL) {
+		// Move back to undo the previous action.
+		action_list_move(e->undo_list, -1);
+	}
+
+	if (e->undo_list->curr_status != NODE) {
+		// Either curr is before head or the list is empty.
 		editor_statusmessage(e, STATUS_INFO, "No action to undo");
 		return;
 	}
@@ -1106,9 +1113,8 @@ void editor_undo(struct editor* e) {
 			action_list_size(e->undo_list) - 1); // subtract one due to the deletion
 			                                     // in the next statement
 
-	// pop it for now, from the list.
-	action_list_delete(e->undo_list, last_action);
-
+	// Move to the previous action.
+	action_list_move(e->undo_list, -1);
 }
 
 /*

--- a/editor.c
+++ b/editor.c
@@ -547,7 +547,7 @@ void editor_render_help(struct editor* e) {
 		"n       : Search for next occurrence.\r\n"
 		"N       : Search for previous occurrence.\r\n"
 		"u       : Undo the last action.\r\n"
-		"R       : Redo the last undone action.\r\n"
+		"CTRL+R  : Redo the last undone action.\r\n"
 		"\r\n");
 	charbuf_appendf(b,
 		"a       : Append mode. Appends a byte after the current cursor position.\r\n"
@@ -1042,8 +1042,8 @@ void editor_process_keypress(struct editor* e) {
 		case ':': editor_setmode(e, MODE_COMMAND);      return;
 		case '/': editor_setmode(e, MODE_SEARCH);       return;
 
-		case 'u':  editor_undo(e); return;
-		case 'R' : editor_redo(e); return;
+		case 'u':         editor_undo(e); return;
+		case KEY_CTRL_R : editor_redo(e); return;
 
 		// move `grouping` amount back or forward:
 		case 'b': editor_move_cursor(e, KEY_LEFT, e->grouping); break;

--- a/editor.c
+++ b/editor.c
@@ -547,6 +547,7 @@ void editor_render_help(struct editor* e) {
 		"n       : Search for next occurrence.\r\n"
 		"N       : Search for previous occurrence.\r\n"
 		"u       : Undo the last action.\r\n"
+		"R       : Redo the last undone action.\r\n"
 		"\r\n");
 	charbuf_appendf(b,
 		"a       : Append mode. Appends a byte after the current cursor position.\r\n"

--- a/editor.c
+++ b/editor.c
@@ -1109,15 +1109,15 @@ void editor_undo(struct editor* e) {
 	// move cursor to the undone action's offset.
 	editor_scroll_to_offset(e, last_action->offset);
 
+	// Move to the previous action.
+	action_list_move(e->undo_list, -1);
+
 	editor_statusmessage(e, STATUS_INFO,
 		"Reverted '%s' at offset %d to byte '%02x' (%d left)",
 			action_type_name(last_action->act),
 			last_action->offset,
 			last_action->c,
-			action_list_size(e->undo_list) - 1); // TODO
-
-	// Move to the previous action.
-	action_list_move(e->undo_list, -1);
+			action_list_curr_pos(e->undo_list));
 }
 
 void editor_redo(struct editor* e) {
@@ -1162,15 +1162,16 @@ void editor_redo(struct editor* e) {
 	// Move cursor to the redone action's offset.
 	editor_scroll_to_offset(e, next_action->offset);
 
+	// Move to the next action.
+	action_list_move(e->undo_list, 1);
+
 	editor_statusmessage(e, STATUS_INFO,
 		"Redone '%s' at offset %d to byte '%02x' (%d left)",
 			action_type_name(next_action->act),
 			next_action->offset,
 			next_action->c,
-			action_list_size(e->undo_list) - 1); // TODO
-
-	// Move to the previous action.
-	action_list_move(e->undo_list, 1);
+			action_list_size(e->undo_list)
+			- action_list_curr_pos(e->undo_list));
 }
 
 /*

--- a/editor.h
+++ b/editor.h
@@ -248,6 +248,11 @@ int editor_statusmessage(struct editor* e, enum status_severity s, const char* f
 void editor_undo(struct editor* e);
 
 /*
+ * Redoes an action.
+ */
+void editor_redo(struct editor* e);
+
+/*
  * Writes the contents of the editor's buffer the to the same filename.
  */
 void editor_writefile(struct editor* e);

--- a/hx.1
+++ b/hx.1
@@ -107,7 +107,7 @@ N          : search for previous occurrence.
 .It
 u          : undo the last action, until the undo stack is empty.
 .It
-R          : redo the last undone action, until there is nothing left to redo.
+CTRL+R     : redo the last undone action, until there is nothing left to redo.
 .It
 a          : enable APPEND mode.
 .It

--- a/hx.1
+++ b/hx.1
@@ -107,6 +107,8 @@ N          : search for previous occurrence.
 .It
 u          : undo the last action, until the undo stack is empty.
 .It
+R          : redo the last undone action, until there is nothing left to redo.
+.It
 a          : enable APPEND mode.
 .It
 A          : enable APPEND-ASCII mode.

--- a/undo.c
+++ b/undo.c
@@ -27,6 +27,7 @@ struct action_list* action_list_init() {
 	struct action_list* list = malloc(sizeof(struct action_list));
 	list->head = NULL;
 	list->tail = NULL;
+	list->curr = NULL;
 	return list;
 }
 
@@ -52,6 +53,8 @@ void action_list_add(struct action_list* list, enum action_type type, int offset
 		// Then
 		list->tail = action;
 	}
+
+	list->curr = action;
 }
 
 void action_list_delete(struct action_list* list, struct action* action) {
@@ -76,11 +79,13 @@ void action_list_delete(struct action_list* list, struct action* action) {
 	}
 
 	bool remove = (action == list->head);
+	bool curr_removed = false;
 
 	// temp node
 	struct action* node = action;
 	while (node != NULL) {
 		struct action* temp = node;
+		if (list->curr == temp) curr_removed = true;
 		node = temp->next;
 		free(temp);
 		temp = NULL;
@@ -90,6 +95,9 @@ void action_list_delete(struct action_list* list, struct action* action) {
 		list->head = NULL;
 		list->tail = NULL;
 	}
+
+	// If curr was removed it was after tail - so move it to the latest.
+	if (curr_removed) list->curr = list->tail;
 }
 
 void action_list_free(struct action_list* list) {

--- a/undo.c
+++ b/undo.c
@@ -141,7 +141,17 @@ unsigned int action_list_size(struct action_list* list) {
 }
 
 void action_list_move(struct action_list* list, int direction) {
-	(void)list;
-	(void)direction;
+	if (direction == 0) return;
+	if (list == NULL) return;
+	// This should never happen if the last check passed.
+	if (list->curr == NULL) return;
+
+	if (direction > 0) {
+		// Move forward.
+		if (list->curr != list->tail) list->curr = list->curr->next;
+	} else {
+		// Move backwards
+		if (list->curr != list->head) list->curr = list->curr->prev;
+	}
 }
 

--- a/undo.c
+++ b/undo.c
@@ -158,6 +158,19 @@ unsigned int action_list_size(struct action_list* list) {
 	return size;
 }
 
+unsigned int action_list_curr_pos(struct action_list* list) {
+	if (list->curr == NULL) return 0;
+	unsigned int size = 1;
+	struct action* node = list->head;
+
+	for (node = list->head; node != NULL && node != list->curr;
+	     node = node->next) {
+		++size;
+	}
+
+	return size;
+}
+
 void action_list_move(struct action_list* list, int direction) {
 	if (direction == 0) return;
 	if (list == NULL) return;

--- a/undo.c
+++ b/undo.c
@@ -132,3 +132,8 @@ unsigned int action_list_size(struct action_list* list) {
 	return size;
 }
 
+void action_list_move(struct action_list* list, int direction) {
+	(void)list;
+	(void)direction;
+}
+

--- a/undo.c
+++ b/undo.c
@@ -41,6 +41,16 @@ void action_list_add(struct action_list* list, enum action_type type, int offset
 	action->offset = offset;
 	action->c = c;
 
+	// Delete the nodes after curr so as to "reset" the redo state.
+	// We redo the head check since delete may change head.
+	if (list->head != NULL) {
+		// If curr IS tail, we want to just add to the end of the list,
+		// so there is nothing to delete.
+		if (list->curr != list->tail) {
+			action_list_delete(list, list->curr->next);
+		}
+	}
+
 	if (list->head == NULL) {
 		// is this the first node added to the list?
 		list->head = action;
@@ -54,6 +64,7 @@ void action_list_add(struct action_list* list, enum action_type type, int offset
 		list->tail = action;
 	}
 
+	// curr is the new action unconditionally.
 	list->curr = action;
 }
 

--- a/undo.h
+++ b/undo.h
@@ -101,6 +101,12 @@ void action_list_print(struct action_list* list);
 unsigned int action_list_size(struct action_list* list);
 
 /*
+ * Gets the position of curr in the list. A value of 0 means curr
+ * is before the head (so curr == head means it's at position 1).
+ */
+unsigned int action_list_curr_pos(struct action_list* list);
+
+/*
  * Moves the curr pointer forwards or backwards one action within the
  * action_list according to direction.
  * If direction < 0, then curr moves backwards.

--- a/undo.h
+++ b/undo.h
@@ -51,8 +51,9 @@ const char* action_type_name(enum action_type type);
  * to operate on this struct to add or delete `action's.
  */
 struct action_list {
-	struct action* head; // head/start of the list
-	struct action* tail; // tail/end of the list.
+	struct action* head; // Head/start of the list.
+	struct action* curr; // Current position within the list.
+	struct action* tail; // Tail/end of the list.
 };
 
 /*
@@ -89,5 +90,14 @@ void action_list_print(struct action_list* list);
  * Gets the size of the list.
  */
 unsigned int action_list_size(struct action_list* list);
+
+/*
+ * Moves the curr pointer forwards or backwards one action within the
+ * action_list according to direction.
+ * If direction < 0, then curr moves backwards.
+ * If direction > 0, then curr moves forward.
+ * (Does nothing if direction == 0.)
+ */
+void action_list_move(struct action_list* list, int direction);
 
 #endif // HX_UNDO_H

--- a/undo.h
+++ b/undo.h
@@ -10,11 +10,12 @@
 /*
  * Contains definitions and functions to allow undo/redo actions.
  * It's basically a double-linked list, where the tail is the last
- * action done, and the head the first. By undoing, the tail is
- * currently removed. Needs further work.
+ * action done, and the head the first. curr points to the last
+ * performed action - so undoing undoes curr and redoing redoes
+ * curr->next.
  */
 
-// Type of undo actions.
+// Type of undo/redo actions.
 enum action_type {
 	ACTION_DELETE,  // character deleted
 	ACTION_INSERT,  // character inserted

--- a/undo.h
+++ b/undo.h
@@ -22,6 +22,14 @@ enum action_type {
 	ACTION_APPEND   // character appended
 };
 
+/* The status of the position that curr is currently at. */
+enum curr_pos {
+	BEFORE_HEAD,  // curr is NULL and before head.
+	NODE,         // curr points to an action.
+	AFTER_TAIL,   // curr is NULL and after tail.
+	NOTHING       // curr is NULL and none of the above.
+};
+
 /*
  * This struct contains the data about an action, as well as the pointers
  * to the previous action (or NULL if this is the first), the next action
@@ -51,9 +59,10 @@ const char* action_type_name(enum action_type type);
  * to operate on this struct to add or delete `action's.
  */
 struct action_list {
-	struct action* head; // Head/start of the list.
-	struct action* curr; // Current position within the list.
-	struct action* tail; // Tail/end of the list.
+	struct action* head;  // Head/start of the list.
+	struct action* curr;  // Current position within the list.
+	enum curr_pos curr_status; // Meta position of curr.
+	struct action* tail;  // Tail/end of the list.
 };
 
 /*

--- a/util.h
+++ b/util.h
@@ -15,6 +15,7 @@ enum key_codes {
 	KEY_NULL      = 0,
 	KEY_CTRL_D    = 0x04,
 	KEY_CTRL_Q    = 0x11, // DC1, to exit the program.
+	KEY_CTRL_R    = 0x12, // DC2, to redo an action.
 	KEY_CTRL_S    = 0x13, // DC2, to save the current buffer.
 	KEY_CTRL_U    = 0x15,
 	KEY_ESC       = 0x1b, // ESC, for things like keys up, down, left, right, delete, ...

--- a/util.h
+++ b/util.h
@@ -16,7 +16,7 @@ enum key_codes {
 	KEY_CTRL_D    = 0x04,
 	KEY_CTRL_Q    = 0x11, // DC1, to exit the program.
 	KEY_CTRL_R    = 0x12, // DC2, to redo an action.
-	KEY_CTRL_S    = 0x13, // DC2, to save the current buffer.
+	KEY_CTRL_S    = 0x13, // DC3, to save the current buffer.
 	KEY_CTRL_U    = 0x15,
 	KEY_ESC       = 0x1b, // ESC, for things like keys up, down, left, right, delete, ...
 	KEY_ENTER     = 0x0d,


### PR DESCRIPTION
Hi,

I've always had trouble with nice simple hex editors and this looks great. I saw redo in the TODO list in the README so I gave it a shot, here it is.

Some points on the design changes I made,
- the action_list maintains a "curr" pointer pointing to the last action that was done
- on undo, curr is undone, and on redo, curr->next is undone (respecting boundaries of course)
- unfortunately, to avoid infinitely undoing head, curr sometimes needs to move "before head" (and after tail for simplicity), a curr_status field indicates where curr is - before head, after tail, a node, or nothing (standard null)
- an undo moves curr back, a redo advances curr forward
- adding to the action_list deletes the elements after curr, i.e. it resets the "redo list" so to speak

Some concerns,
- the redo hotkey is 'R' - I wanted to do ctrl+r (like Vim) though I couldn't really work out how the codes are determined currently and one of the lists I found online seemed to suggest that ctrl+r overlaps with another key
- unfortunately I had to flip the character associated with a replace action on any associated undo/redo - imagine undoing a replace than redoing it, well... you need both the replacer and replacee
- The message shown after a redo is "Redone ..." - sounds a bit weird haha