### PR TITLE
Fix backspace for xterm (and potentially others).

### DIFF
--- a/util.c
+++ b/util.c
@@ -112,6 +112,9 @@ int read_key() {
 	char seq[4]; // escape sequence buffer.
 
 	switch (c) {
+	case KEY_BACKSPACE:
+	case KEY_CTRL_H:
+		return KEY_BACKSPACE;
 	case KEY_ESC:
 		// Escape key was pressed, OR things like delete, arrow keys, ...
 		// So we will try to read ahead a few bytes, and see if there's more.

--- a/util.h
+++ b/util.h
@@ -14,6 +14,7 @@
 enum key_codes {
 	KEY_NULL      = 0,
 	KEY_CTRL_D    = 0x04,
+	KEY_CTRL_H    = 0x08,
 	KEY_CTRL_Q    = 0x11, // DC1, to exit the program.
 	KEY_CTRL_R    = 0x12, // DC2, to redo an action.
 	KEY_CTRL_S    = 0x13, // DC3, to save the current buffer.


### PR DESCRIPTION
Fix is as suggested by Kevin Pors in issue #15.