### PR TITLE
Initialise field "dirty" in editor_init

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -1201,6 +1201,7 @@ struct editor* editor_init() {
 	e->filename = NULL;
 	e->contents = NULL;
 	e->content_length = 0;
+	e->dirty = false;
 
 	memset(e->status_message, '\0', sizeof(e->status_message));
 


### PR DESCRIPTION
From issue #16 


```
valgrind -v --track-origins=yes ./hx hx
... bunch of stuff ...
==8112== HEAP SUMMARY:
==8112==     in use at exit: 0 bytes in 0 blocks
==8112==   total heap usage: 23 allocs, 23 frees, 85,169 bytes allocated
==8112== 
==8112== All heap blocks were freed -- no leaks are possible
==8112== 
==8112== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
==8112== 
==8112== 1 errors in context 1 of 1:
==8112== Conditional jump or move depends on uninitialised value(s)
==8112==    at 0x10ADE1: editor_process_command (in /home/mohamad/hx/hx)
==8112==    by 0x10BEB3: editor_process_keypress (in /home/mohamad/hx/hx)
==8112==    by 0x10931F: main (in /home/mohamad/hx/hx)
==8112==  Uninitialised value was created by a heap allocation
==8112==    at 0x4C2CE5F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8112==    by 0x10C3BA: editor_init (in /home/mohamad/hx/hx)
==8112==    by 0x1092CC: main (in /home/mohamad/hx/hx)
==8112== 
==8112== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
This is from just quitting immediately. Initially I thought it was an alignment thing, so there's some "gap" bytes in the editor struct malloc'd in editor_init being read (maybe a full copy or something), and calloc fixes the issue. Then I noticed editor_init does not initialise the dirty field.

This satisfies the error valgrind was reporting.